### PR TITLE
Adds: VictoriaLogs, Hashicorp Nomad

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ A curated list of Platform and Production Engineering tools - Maintained by [Sai
 
 ### Container Orchestration
 - [Kubernetes](https://kubernetes.io/)
+- [Nomad](https://github.com/hashicorp/nomad)
 - [Docker Swarm](https://docs.docker.com/engine/swarm/)
 - [Apache Mesos](http://mesos.apache.org/) - with [Marathon](https://mesosphere.github.io/marathon/)
 

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ A curated list of Platform and Production Engineering tools - Maintained by [Sai
 - [Healthchecks.io](https://healthchecks.io)
 - [OnlineOrNot](https://onlineornot.com/) - Uptime monitoring for websites, APIs, and cron jobs, with integrated status pages.
 - [ELK Stack (Elasticsearch, Logstash, Kibana)](https://www.elastic.co/elastic-stack)
+- [VictoriaLogs database for logs from VictoriaMetrics](https://docs.victoriametrics.com/victorialogs/)
 - [OpenTelemetry](https://opentelemetry.io/)
 
 


### PR DESCRIPTION
This PR will add:
1. Nomad to [Container Orchestration](https://github.com/seifrajhi/awesome-platform-engineering-tools#container-orchestration) section.
2. VictoriaLogs to [Continuous Monitoring](https://github.com/seifrajhi/awesome-platform-engineering-tools#continuous-monitoring) section