### PR TITLE
Add Depot to container tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A curated list of Platform and Production Engineering tools - Maintained by [Sai
 
 
 ### Container
+- [Depot](https://depot.dev/)
 - [Docker](https://www.docker.com/)
 - [Turbo.NET](https://turbo.net/)
 - [WinDocks](https://windocks.com/)


### PR DESCRIPTION
Depot is a remote container build service that builds images faster.

This might be more relevant in the `Build` section, but I leave it up to you.