### PR TITLE
add Meshery, Kanvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ A curated list of Platform and Production Engineering tools - Maintained by [Sai
 - [Packer](https://www.packer.io/)
 - [Kubestack](https://github.com/kbst/terraform-kubestack)
 - [Shipyard](https://shipyard.build/) - Ephemeral environment management platform.
+- [Meshery](https://meshery.io) - A open source cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud).
+- [Kanvas](https://kanvas.new) - A collaborative tool with visual interface for designing and operating infrastructure.
 
 ### Container
 


### PR DESCRIPTION
This PR lists


[Kanvas](https://kanvas.new/) - A Collaborative designer and operator for cloud native infrastrucuture.
[Meshery](https://github.com/meshery/meshery) - a highly extensible, CNCF project, that enables collaborative design and operation of cloud-native infrastructure.