### PR TITLE
feat: add KubeStellar Console to AI powered platform tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of Platform and Production Engineering tools - Maintained by [Sai
 - [Monolith](https://www.monolithai.com/) - No-code AI software built for engineers.
 - [Viktor](https://www.viktor.ai/) - Implement AI in your engineering workflow.
 - [initializ.ai](https://www.initializ.ai/) - AI-Driven Unified DevSecOps Platform.
+- [KubeStellar Console](https://github.com/kubestellar/console) - AI-powered multi-cluster Kubernetes dashboard with real-time observability, MCP agent integration, and 20+ CNCF project integrations across edge and cloud clusters.
   
 ## Development
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **AI powered platform tools** section.

KubeStellar Console is an open source AI-powered multi-cluster Kubernetes dashboard (CNCF Sandbox project). Its kc-agent component is an MCP server that bridges AI assistants to Kubernetes clusters, with support for 20+ CNCF integrations across edge and cloud clusters.

- GitHub: https://github.com/kubestellar/console
- Live demo: https://console.kubestellar.io